### PR TITLE
Pin Python images to 3.7 where peewee is required

### DIFF
--- a/source-code/chapter-5/exercise-2/newsbot/Dockerfile
+++ b/source-code/chapter-5/exercise-2/newsbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7-alpine
 
 RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev
 WORKDIR /apps/subredditfetcher/

--- a/source-code/chapter-7/exercise-2/newsbot-compose/Dockerfile
+++ b/source-code/chapter-7/exercise-2/newsbot-compose/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3-alpine
+FROM python:3.7-alpine
 
-RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo
+RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev
 WORKDIR /apps/subredditfetcher/
 COPY . .
 


### PR DESCRIPTION
Installing peewee complains about a missing name when python-3 image is used, which automatically points to the latest dot versions. Python 3.10 has a breaking change to collections, and this results in Docker build failing. 

```
#9 7.039 Collecting peewee==2.10.2
#9 7.207   Downloading peewee-2.10.2.tar.gz (516 kB)
#9 7.501      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 516.1/516.1 kB 1.7 MB/s eta 0:00:00
#9 7.547   Preparing metadata (setup.py): started
#9 7.851   Preparing metadata (setup.py): finished with status 'error'
#9 7.857   error: subprocess-exited-with-error
#9 7.857
#9 7.857   × python setup.py egg_info did not run successfully.
#9 7.857   │ exit code: 1
#9 7.857   ╰─> [10 lines of output]
#9 7.857       /tmp/pip-install-6zjexq0d/peewee_a7055874ed7f4df497681689fb4ae6cd/setup.py:21: UserWarning: Cython C extensions for peewee will NOT be built, because Cython does not seem to be installed. To enable Cython C extensions, install Cython >=0.22.1.
#9 7.857         warnings.warn('Cython C extensions for peewee will NOT be built, because '
#9 7.857       Traceback (most recent call last):
#9 7.857         File "<string>", line 2, in <module>
#9 7.857         File "<pip-setuptools-caller>", line 34, in <module>
#9 7.857         File "/tmp/pip-install-6zjexq0d/peewee_a7055874ed7f4df497681689fb4ae6cd/setup.py", line 64, in <module>
#9 7.857           version=__import__('peewee').__version__,
#9 7.857         File "/tmp/pip-install-6zjexq0d/peewee_a7055874ed7f4df497681689fb4ae6cd/peewee.py", line 124, in <module>
#9 7.857           from collections import Callable
#9 7.857       ImportError: cannot import name 'Callable' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
#9 7.857       [end of output]
#9 7.857
#9 7.857   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 7.859 error: metadata-generation-failed
#9 7.859
#9 7.859 × Encountered error while generating package metadata.
#9 7.859 ╰─> See above for output.
#9 7.859
#9 7.859 note: This is an issue with the package mentioned above, not pip.
#9 7.859 hint: See above for details.
```

fixes #25 

Updates chapter 5 & 7 Dockerfiles.

